### PR TITLE
Delete any CSS containment when visible

### DIFF
--- a/view/frontend/templates/html/header.phtml
+++ b/view/frontend/templates/html/header.phtml
@@ -74,8 +74,7 @@ $showMiniCart = $storeConfig->getStoreConfig(SidebarCart::XML_PATH_CHECKOUT_SIDE
     <div class="w-full transition-transform duration-300"
          :class="{
             'theme-bg-grey6 fixed top-0 z-20 shadow-md': !scrollAtTop,
-            '-translate-y-full': scrolledDown && !scrollAtTop,
-            'translate-y-0': !scrolledDown || scrollAtTop
+            '-translate-y-full': scrolledDown && !scrollAtTop
         }">
     <div id="header"
          class="relative z-30 w-full border-b shadow bg-container-lighter border-container-lighter"


### PR DESCRIPTION
Closes #1 

The issue created when using any CSS proprty that creates CSS containment, in this case `translate`.

Also there is no need to set this value when animation from any other translate values, since this is the initial state.